### PR TITLE
fix failing tests

### DIFF
--- a/samples/tests/src/test/java/com/example/OtherMavenIT.java
+++ b/samples/tests/src/test/java/com/example/OtherMavenIT.java
@@ -48,7 +48,7 @@ public class OtherMavenIT {
 		}
 		for (File build : dir.listFiles()) {
 			if (build.getName().startsWith("spring-boot-thin-launcher")
-					&& build.getName().endsWith(".jar")) {
+					&& build.getName().endsWith("-exec.jar")) {
 				launcherJar = build.getAbsolutePath();
 			}
 		}

--- a/wrapper/src/test/java/org/springframework/boot/loader/wrapper/ThinJarWrapperTests.java
+++ b/wrapper/src/test/java/org/springframework/boot/loader/wrapper/ThinJarWrapperTests.java
@@ -96,14 +96,19 @@ public class ThinJarWrapperTests {
 		String value = null;
 		for (Entry<String, String> entry : System.getenv().entrySet()) {
 			if (entry.getKey().contains("_")) {
-				key = entry.getKey();
-				value = entry.getValue();
+				String relaxedKey = entry.getKey().toLowerCase().replace("_", ".");
+				// since ThinJarWrapper gives system properties precedence, we only want
+				// an env var whose key is not also in relaxed form as a system property
+				if (System.getProperty(relaxedKey) == null) {
+					key = relaxedKey;
+					value = entry.getValue();
+				}
 				break;
 			}
 		}
 		if (key != null) {
 			assertEquals(value,
-					ThinJarWrapper.getProperty(key.toLowerCase().replace("_", ".")));
+					ThinJarWrapper.getProperty(key));
 		}
 		else {
 			System.err.println("WARN: no testable env var");


### PR DESCRIPTION
- when testing env vars for relaxed binding, bypass any system properties
- launcher jar includes `-exec` qualifier