### PR TITLE
Workaround for Maven authentication support

### DIFF
--- a/launcher/src/main/java/org/springframework/boot/loader/thin/DependencyResolver.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/DependencyResolver.java
@@ -306,6 +306,7 @@ public class DependencyResolver {
 		disabled.setEnabled(false);
 		repository.setReleaseUpdatePolicy(releases ? enabled : disabled);
 		repository.setSnapshotUpdatePolicy(snapshots ? enabled : disabled);
+		repository.setAuthentication(settings.getRepositoryAuthentication(id));
 		return repository;
 	}
 

--- a/launcher/src/main/java/org/springframework/boot/loader/thin/MavenSettings.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/MavenSettings.java
@@ -70,6 +70,8 @@ public class MavenSettings {
 
 	private final AuthenticationSelector authenticationSelector;
 
+	private final Map<String, org.apache.maven.artifact.repository.Authentication> repositoryAuthentications;
+
 	private final ProxySelector proxySelector;
 
 	private final String localRepository;
@@ -85,9 +87,27 @@ public class MavenSettings {
 		this.offline = settings.isOffline();
 		this.mirrorSelector = createMirrorSelector(settings);
 		this.authenticationSelector = createAuthenticationSelector(decryptedSettings);
+		this.repositoryAuthentications = createRepositoryAuthentications(decryptedSettings);
 		this.proxySelector = createProxySelector(decryptedSettings);
 		this.localRepository = settings.getLocalRepository();
 		this.activeProfiles = determineActiveProfiles(settings);
+	}
+
+	public org.apache.maven.artifact.repository.Authentication getRepositoryAuthentication(String id) {
+		return repositoryAuthentications.get(id);
+	}
+
+	private Map<String, org.apache.maven.artifact.repository.Authentication> createRepositoryAuthentications(SettingsDecryptionResult decryptedSettings){
+		Map<String, org.apache.maven.artifact.repository.Authentication> repositoryAuthentications = new HashMap<>();
+		for(Server server : decryptedSettings.getServers()){
+			org.apache.maven.artifact.repository.Authentication authentication = new org.apache.maven.artifact.repository.Authentication(
+					server.getUsername(), server.getPassword()
+			);
+			authentication.setPassphrase(server.getPassphrase());
+			authentication.setPrivateKey(server.getPrivateKey());
+			repositoryAuthentications.put(server.getId(), authentication);
+		}
+		return repositoryAuthentications;
 	}
 
 	private MirrorSelector createMirrorSelector(Settings settings) {

--- a/launcher/src/main/java/org/springframework/boot/loader/thin/MavenSettings.java
+++ b/launcher/src/main/java/org/springframework/boot/loader/thin/MavenSettings.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.maven.model.ActivationFile;
 import org.apache.maven.model.ActivationOS;


### PR DESCRIPTION
Fixes #23 in a quick and dirty way. It's just an example for getting it running. The Aether stuff is very confusing and you'll find hopefully a better way than me.