### PR TITLE
Use `tag` instead of `label` in `image_resource`

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -29,7 +29,7 @@ jobs:
         type: docker-image
         source: 
           repository: openjdk
-          label: 8-jdk-alpine
+          tag: 8-jdk-alpine
       inputs:
         - name: source
       caches:


### PR DESCRIPTION
As documented here:
https://github.com/concourse/docker-image-resource

> tag: Optional. The tag to track. Defaults to latest.